### PR TITLE
Fix typos in Jupyter post

### DIFF
--- a/content/post/jupyter/index.md
+++ b/content/post/jupyter/index.md
@@ -47,9 +47,9 @@ The `jupyter` command above will launch the JupyterLab editor, allowing us to ad
 
 ## Edit your post metadata
 
-The first cell of your Jupter notebook will contain your post metadata ([front matter](https://sourcethemes.com/academic/docs/front-matter/)).
+The first cell of your Jupyter notebook will contain your post metadata ([front matter](https://sourcethemes.com/academic/docs/front-matter/)).
 
-In Jupter, choose _Markdown_ as the type of the first cell and wrap your Academic metadata in three dashes, indicating that it is YAML front matter:
+In Jupyter, choose _Markdown_ as the type of the first cell and wrap your Academic metadata in three dashes, indicating that it is YAML front matter:
 
 ```
 ---
@@ -74,4 +74,4 @@ jupyter nbconvert index.ipynb --to markdown --NbConvertApp.output_files_dir=.
 
 ## Example
 
-This post was created with Jupyter. The orginal files can be found at https://github.com/gcushen/hugo-academic/tree/master/exampleSite/content/post/jupyter
+This post was created with Jupyter. The original files can be found at https://github.com/gcushen/hugo-academic/tree/master/exampleSite/content/post/jupyter


### PR DESCRIPTION
## Summary
- fix typos in the Jupyter notebook instructions

## Testing
- `yamllint config/_default/`


------
https://chatgpt.com/codex/tasks/task_e_684adb86771083279d35c4d1fcd5307e